### PR TITLE
Try vanilla local storage solution which fails …

### DIFF
--- a/hooks/useLocalStorage.js
+++ b/hooks/useLocalStorage.js
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * A hook to use localStorage with SSR.
+ *
+ * Make sure that localStorage and state do not conflict with each other.
+ * Only update the state if no initialState was read from localStorage.
+ *
+ * @param {string} key
+ * @param {unknown} initialState
+ * @returns {[unknown, (value: unknown) => void]}
+ */
+export default function useLocalStorage(key, initialState) {
+  // Set the desired initialState
+  const [stateValue, setStateValue] = useState(initialState);
+
+  // Provide a custom setter function that updates the state and writes to localStorage
+  const setStateAndUpdateLocalStorage = useCallback(
+    (value) => {
+      setStateValue(value);
+      window.localStorage.setItem(key, JSON.stringify(value));
+    },
+    [key]
+  );
+
+  // Read the localStorage from the client
+  useEffect(() => {
+    const stored = JSON.parse(window.localStorage.getItem(key));
+    // When the stored value === null
+    // Then the key does not exist, and we don't want to perform an update
+    if (stored !== null) {
+      setStateValue(stored);
+    }
+  }, [key]);
+
+  return [stateValue, setStateAndUpdateLocalStorage];
+}

--- a/hooks/useLocalStorage.js
+++ b/hooks/useLocalStorage.js
@@ -25,11 +25,11 @@ export default function useLocalStorage(key, initialState) {
 
   // Read the localStorage from the client
   useEffect(() => {
-    const stored = JSON.parse(window.localStorage.getItem(key));
+    const stored = window.localStorage.getItem(key);
     // When the stored value === null
     // Then the key does not exist, and we don't want to perform an update
     if (stored !== null) {
-      setStateValue(stored);
+      setStateValue(JSON.parse(stored));
     }
   }, [key]);
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true, // by default / try false to make local storage work
+  reactStrictMode: true,
   swcMinify: true,
   images: {
     domains: ['raw.githubusercontent.com'],

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: true, // by default / try false to make local storage work
   swcMinify: true,
   images: {
     domains: ['raw.githubusercontent.com'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
         "next": "12.2.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "styled-components": "^5.3.5",
-        "use-local-storage-state": "^18.1.1"
+        "styled-components": "^5.3.5"
       },
       "devDependencies": {
         "eslint": "8.23.0",
@@ -3400,21 +3399,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-local-storage-state": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/use-local-storage-state/-/use-local-storage-state-18.1.1.tgz",
-      "integrity": "sha512-09bl6q3mkSlkEt8KeBPCmdPEWEojWYF70Qbz+7wkfQX1feaFITM9m84+h0Jr6Cnf/IvpahkFh7UbX2VNN3ioTQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/astoilkov"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -5868,12 +5852,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "use-local-storage-state": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/use-local-storage-state/-/use-local-storage-state-18.1.1.tgz",
-      "integrity": "sha512-09bl6q3mkSlkEt8KeBPCmdPEWEojWYF70Qbz+7wkfQX1feaFITM9m84+h0Jr6Cnf/IvpahkFh7UbX2VNN3ioTQ==",
-      "requires": {}
     },
     "use-sync-external-store": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "next": "12.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "styled-components": "^5.3.5",
-    "use-local-storage-state": "^18.1.1"
+    "styled-components": "^5.3.5"
   },
   "devDependencies": {
     "eslint": "8.23.0",

--- a/pages/basket.js
+++ b/pages/basket.js
@@ -1,12 +1,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import styled from 'styled-components';
-import useLocalStorageState from 'use-local-storage-state';
+import useLocalStorage from '../hooks/useLocalStorage';
 
 import Header from '../components/Header';
 
 export default function ShoppingCart() {
-  const [cart, _] = useLocalStorageState('_cart', { defaultValue: [] });
+  const [cart] = useLocalStorage('_cart', []);
 
   return (
     <main>

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Header from '../components/Header';
 import ShoppingItem from '../components/ShoppingItem';
 import Image from 'next/image';
-
+import { useState, useEffect } from 'react';
 import useLocalStorageState from 'use-local-storage-state';
 
 export async function getServerSideProps() {
@@ -32,7 +32,21 @@ export async function getServerSideProps() {
 }
 
 export default function Home({ items }) {
-  const [cart, setCart] = useLocalStorageState('_cart', { defaultValue: [] });
+  console.log('RENDER');
+
+  //const [cart, setCart] = useLocalStorageState('_cart', { defaultValue: [] });
+  const [cart, setCart] = useState([]);
+
+  useEffect(() => {
+    const storedItems = JSON.parse(localStorage.getItem('_cart'));
+    debugger;
+    setCart(storedItems ?? []);
+  }, []);
+
+  useEffect(() => {
+    debugger;
+    localStorage.setItem('_cart', JSON.stringify(cart));
+  }, [cart]);
 
   function addToCart(item) {
     const existingCartItem = cart.find((cartItem) => cartItem.id === item.id);

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,8 +3,7 @@ import styled from 'styled-components';
 import Header from '../components/Header';
 import ShoppingItem from '../components/ShoppingItem';
 import Image from 'next/image';
-import { useState, useEffect } from 'react';
-import useLocalStorageState from 'use-local-storage-state';
+import useLocalStorage from '../hooks/useLocalStorage';
 
 export async function getServerSideProps() {
   const response = await fetch('https://pokeapi.co/api/v2/item/');
@@ -32,21 +31,7 @@ export async function getServerSideProps() {
 }
 
 export default function Home({ items }) {
-  console.log('RENDER');
-
-  //const [cart, setCart] = useLocalStorageState('_cart', { defaultValue: [] });
-  const [cart, setCart] = useState([]);
-
-  useEffect(() => {
-    const storedItems = JSON.parse(localStorage.getItem('_cart'));
-    debugger;
-    setCart(storedItems ?? []);
-  }, []);
-
-  useEffect(() => {
-    debugger;
-    localStorage.setItem('_cart', JSON.stringify(cart));
-  }, [cart]);
+  const [cart, setCart] = useLocalStorage('_cart', []);
 
   function addToCart(item) {
     const existingCartItem = cart.find((cartItem) => cartItem.id === item.id);


### PR DESCRIPTION
… due to double render behaviour caused by react´s strict mode

**Expected behaviour:**
Shopping items which are stored in the local storage will be shown after the reload of the page.

**Actual behaviour:**
Shopping cart is empty after reload since the items stored in the local storage will be overwritten by an empty array.

This seems to happen due to React´s strict mode and its double rendering behaviour.

I left two debugger breakpoints which can be used to inspect the effects.

During the first render everything seems fine.
The second render writes an empty array to the local storage (the initial state).

**Possible "solution"**: Set `reactStrictMode: true` in `next.config.js` –> Not really an option.
**Save solution**: Use a majestic localStorage hook / module as provided by the npm module `use-local-storage-state`. With this module it works as expected.

But the question remains: can we use a simple, vanilla JS local storage implementation (hook)?

<img width="1000" alt="Screenshot 2022-09-19 at 18 33 12" src="https://user-images.githubusercontent.com/4458383/191077660-4dea1272-08e5-41f7-ad45-f88aa95f8028.png">
<img width="1000" alt="Screenshot 2022-09-19 at 18 33 44" src="https://user-images.githubusercontent.com/4458383/191076767-7199e615-3ed5-47d8-8e67-6c69010983e1.png">
<img width="1000" alt="Screenshot 2022-09-19 at 18 34 09" src="https://user-images.githubusercontent.com/4458383/191076815-8072b3c5-9b59-4827-8b0d-58b59fddd5e5.png">

